### PR TITLE
Update VoxelSniperListener.java

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperListener.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/VoxelSniperListener.java
@@ -840,7 +840,7 @@ public class VoxelSniperListener implements Listener
     /**
      * @param event
      */
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public final void onPlayerInteract(final PlayerInteractEvent event)
     {
         if (event.isBlockInHand())


### PR DESCRIPTION
DO ignore cancelled player interact. This is so voxelsniper respects when the event is cancelled by other plugins.
