### PR TITLE
Wrap Player keys in a WeakReference in the map.

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/SniperManager.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/SniperManager.java
@@ -1,8 +1,10 @@
 package com.thevoxelbox.voxelsniper;
 
+import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
 import org.bukkit.entity.Player;
 
+import java.lang.ref.WeakReference;
 import java.util.Map;
 
 /**
@@ -10,7 +12,7 @@ import java.util.Map;
  */
 public class SniperManager
 {
-    private Map<Player, Sniper> sniperInstances = Maps.newHashMap();
+    private Map<Player, Sniper> sniperInstances = new MapMaker().weakKeys().makeMap();
     private VoxelSniper plugin;
 
     public SniperManager(VoxelSniper plugin)


### PR DESCRIPTION
Prevents a massive memory leak over time as the CraftPlayer objects are, at the moment, NEVER released to allow for GC.
