### PR TITLE
Added possibility to specify exemption list for entity removal

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/EntityRemovalBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/EntityRemovalBrush.java
@@ -5,21 +5,29 @@ import com.thevoxelbox.voxelsniper.SnipeData;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Hanging;
-import org.bukkit.entity.NPC;
-import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.PatternSyntaxException;
 
 /**
  *
  */
 public class EntityRemovalBrush extends Brush
 {
+    private final List<String> exemptions = new ArrayList<String>(3);
+
     /**
      *
      */
     public EntityRemovalBrush()
     {
         this.setName("Entity Removal");
+
+        exemptions.add("org.bukkit.entity.Player");
+        exemptions.add("org.bukkit.entity.Hanging");
+        exemptions.add("org.bukkit.entity.NPC");
     }
 
     private void radialRemoval(SnipeData v)
@@ -28,36 +36,80 @@ public class EntityRemovalBrush extends Brush
         int entityCount = 0;
         int chunkCount = 0;
 
-        entityCount += removeEntities(targetChunk);
-
-        int radius = Math.round(v.getBrushSize() / 16);
-
-        for (int x = targetChunk.getX() - radius; x <= targetChunk.getX() + radius; x++)
+        try
         {
-            for (int z = targetChunk.getZ() - radius; z <= targetChunk.getZ() + radius; z++)
+            entityCount += removeEntities(targetChunk);
+
+            int radius = Math.round(v.getBrushSize() / 16);
+
+            for (int x = targetChunk.getX() - radius; x <= targetChunk.getX() + radius; x++)
             {
-                entityCount += removeEntities(getWorld().getChunkAt(x, z));
-                chunkCount++;
+                for (int z = targetChunk.getZ() - radius; z <= targetChunk.getZ() + radius; z++)
+                {
+                    entityCount += removeEntities(getWorld().getChunkAt(x, z));
+
+                    chunkCount++;
+                }
             }
         }
-        v.sendMessage(ChatColor.GREEN + "Removed " + ChatColor.RED + entityCount + ChatColor.GREEN + " entities out of " + ChatColor.BLUE + chunkCount + ChatColor.GREEN + " chunks.");
+        catch (final PatternSyntaxException pse)
+        {
+            pse.printStackTrace();
+            v.sendMessage(ChatColor.RED + "Error in RegEx: " + ChatColor.LIGHT_PURPLE + pse.getPattern());
+            v.sendMessage(ChatColor.RED + String.format("%s (Index: %d)", pse.getDescription(), pse.getIndex()));
+        }
+        v.sendMessage(ChatColor.GREEN + "Removed " + ChatColor.RED + entityCount + ChatColor.GREEN + " entities out of " + ChatColor.BLUE + chunkCount + ChatColor.GREEN + (chunkCount == 1 ? " chunk." : " chunks."));
     }
 
-    private int removeEntities(Chunk chunk)
+    private int removeEntities(Chunk chunk) throws PatternSyntaxException
     {
         int entityCount = 0;
 
         for (Entity entity : chunk.getEntities())
         {
-            if (entity instanceof Player || entity instanceof Hanging || entity instanceof NPC)
+            if (isClassInExemptionList(entity.getClass()))
             {
                 continue;
             }
+
             entity.remove();
             entityCount++;
         }
 
         return entityCount;
+    }
+
+    private boolean isClassInExemptionList(Class<? extends Entity> entityClass) throws PatternSyntaxException
+    {
+        // Create a list of superclasses and interfaces implemented by the current entity type
+        final List<String> entityClassHierarchy = new ArrayList<String>();
+
+        Class<?> currentClass = entityClass;
+        while (currentClass != null && !currentClass.equals(Object.class))
+        {
+            entityClassHierarchy.add(currentClass.getCanonicalName());
+
+            for (final Class<?> intrf : currentClass.getInterfaces())
+            {
+                entityClassHierarchy.add(intrf.getCanonicalName());
+            }
+
+            currentClass = currentClass.getSuperclass();
+        }
+
+        for (final String exemptionPattern : exemptions)
+        {
+            for (final String typeName : entityClassHierarchy)
+            {
+                if (typeName.matches(exemptionPattern))
+                {
+                    return true;
+                }
+
+            }
+        }
+
+        return false;
     }
 
     @Override
@@ -76,7 +128,55 @@ public class EntityRemovalBrush extends Brush
     public void info(Message vm)
     {
         vm.brushName(getName());
+
+        final StringBuilder exemptionsList = new StringBuilder(ChatColor.GREEN + "Exemptions: " + ChatColor.LIGHT_PURPLE);
+        for (Iterator it = exemptions.iterator(); it.hasNext(); )
+        {
+            exemptionsList.append(it.next());
+            if (it.hasNext())
+            {
+                exemptionsList.append(", ");
+            }
+        }
+        vm.custom(exemptionsList.toString());
+
         vm.size();
+    }
+
+    @Override
+    public void parameters(final String[] par, final SnipeData v)
+    {
+        for (final String currentParam : par)
+        {
+            if (currentParam.startsWith("+") || currentParam.startsWith("-"))
+            {
+                final boolean isAddOperation = currentParam.startsWith("+");
+
+                // +#/-# will suppress auto-prefixing
+                final String exemptionPattern = currentParam.startsWith("+#") || currentParam.startsWith("-#") ?
+                        currentParam.substring(2) :
+                        (currentParam.contains(".") ? currentParam.substring(1) : ".*." + currentParam.substring(1));
+
+                if (isAddOperation)
+                {
+                    exemptions.add(exemptionPattern);
+                    v.sendMessage(String.format("Added %s to entity exemptions list.", exemptionPattern));
+                }
+                else
+                {
+                    exemptions.remove(exemptionPattern);
+                    v.sendMessage(String.format("Removed %s from entity exemptions list.", exemptionPattern));
+                }
+            }
+
+            if (currentParam.equalsIgnoreCase("list-exemptions") || currentParam.equalsIgnoreCase("lex"))
+            {
+                for (final String exemption : exemptions)
+                {
+                    v.sendMessage(ChatColor.LIGHT_PURPLE + exemption);
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Addresses issue #240.

Adds parameter to entity removal brush which allows to specify classes which should be ignored when removing entities.

**/b er list-exemptions** or **/b er lex** to list current exemptions
**/b er exemptions +ClassName** to add a class to the exemption list
**/b er exemptions -ClassName** to remove a class from the list
e.g. **/b er exemptions +Pig** will omit all pigs 

The parser can handle multiple +ClassName/-ClassName in a single **/b er exemptions** call.

Class names are automatically prefixed with org.bukkit.entity. If org.bukkit.entity.<ClassName> doesn't resolve into a class it will try to resolve the input without the prefix.
