### PR TITLE
Reshade external dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,11 @@ shadowJar {
         include(dependency('ninja.leaping.configurate:configurate-core:2.0'))
         include(dependency('com.typesafe:config:1.2.1'))
     }
+	
+	relocate "com.google", "voxelsniper.reshade.com.google"
+	relocate "org.objectweb", "voxelsniper.reshade.org.objectweb"
+	relocate "ninja.leaping.configurate", "voxelsniper.reshade.ninja.leaping.configurate"
+	relocate "com.typesafe", "voxelsniper.reshade.com.typesafe"
 }
 
 reobf {


### PR DESCRIPTION
I don't know why you haven't already done so. Currently VoxelSniper is broken in some Spigot builds because Spigot uses Guava 17 and VoxelSniper requires version 18. It is very problematic in Spigot versions where Guava is sealed... SecurityException prevents doing anything.

Anyway, I think it is simply bad idea to shade code into jar without relocating it if program is running as plugin in many different environments.