### PR TITLE
Fixing Handling of Performers and Cleaning Some Code

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/Message.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/Message.java
@@ -24,6 +24,7 @@
  */
 package com.thevoxelbox.voxelsniper;
 
+import com.thevoxelbox.voxelsniper.brush.PerformBrush;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.text.Text;
@@ -62,7 +63,8 @@ public class Message {
      * Display Center Parameter.
      */
     public void center() {
-        this.snipeData.sendMessage(TextColors.DARK_BLUE, "Brush Center: ", TextColors.DARK_RED, this.snipeData.getCylinderCenter());
+        this.snipeData.sendMessage(TextColors.DARK_BLUE, "Brush Center: ",
+                                    TextColors.DARK_RED, this.snipeData.getCylinderCenter());
     }
 
     /**
@@ -86,19 +88,38 @@ public class Message {
     }
 
     /**
-     * Display performer.
+     * Display performer data.
      *
-     * @param performerName
+     * @param placeMethod
+     * @param replaceMethod
+     * @param usePhysics
      */
-    public void performerName(String performerName) {
-        this.snipeData.sendMessage(TextColors.DARK_PURPLE, "Performer: ", TextColors.DARK_GREEN, performerName);
+    public void performerData(PerformBrush.PerformerType placeMethod,
+                              PerformBrush.PerformerType replaceMethod,
+                              boolean usePhysics) {
+        String physics = usePhysics ? "On" : "Off";
+        this.snipeData.sendMessage(
+                TextColors.DARK_PURPLE,
+                "Performers:",
+                TextColors.GREEN,
+                " place=",
+                TextColors.AQUA,
+                placeMethod,
+                TextColors.GREEN,
+                " replace=",
+                TextColors.AQUA,
+                replaceMethod,
+                TextColors.GREEN,
+                " physics=",
+                TextColors.AQUA,
+                physics);
     }
 
     /**
      * Display replace material.
      */
     public void replace() {
-        this.snipeData.sendMessage(TextColors.AQUA, "Replace Material: ", TextColors.RED, this.snipeData.getReplaceId());
+        this.snipeData.sendMessage(TextColors.DARK_BLUE, "Replace Material: ", TextColors.RED, this.snipeData.getReplaceId());
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/SnipeData.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/SnipeData.java
@@ -24,6 +24,7 @@
  */
 package com.thevoxelbox.voxelsniper;
 
+import com.thevoxelbox.voxelsniper.util.BlockHelper;
 import com.thevoxelbox.voxelsniper.util.VoxelList;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
@@ -178,6 +179,7 @@ public class SnipeData {
     public void setVoxelInkTraits(Map<BlockTrait<?>, Object> traitValues) {
         this.voxelInkTraits.clear();
         this.voxelInkTraits.putAll(traitValues);
+        this.voxelState = BlockHelper.addTraits(this.voxelState.getType().getDefaultState(), traitValues);
     }
 
     public Map<BlockTrait<?>, Object> getReplaceInkTraits() {
@@ -189,6 +191,7 @@ public class SnipeData {
     public void setReplaceInkTraits(Map<BlockTrait<?>, Object> traitValues) {
         this.replaceInkTraits.clear();
         this.replaceInkTraits.putAll(traitValues);
+        this.replaceState = BlockHelper.addTraits(this.replaceState.getType().getDefaultState(), traitValues);
     }
 
     public Sniper owner() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/SnipeData.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/SnipeData.java
@@ -25,14 +25,17 @@
 package com.thevoxelbox.voxelsniper;
 
 import com.thevoxelbox.voxelsniper.util.VoxelList;
-
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
-import org.spongepowered.api.data.key.Key;
-import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.block.trait.BlockTrait;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.World;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 
 public class SnipeData {
 
@@ -43,10 +46,8 @@ public class SnipeData {
     private BlockState voxelState;
     private BlockState replaceState;
     private VoxelList voxelList;
-    private Key<?> voxelInkKey;
-    private Object voxelInkValue;
-    private Key<?> replaceInkKey;
-    private Object replaceInkValue;
+    private Map<BlockTrait<?>, Object> voxelInkTraits;
+    private Map<BlockTrait<?>, Object> replaceInkTraits;
 
     private int voxelHeight;
     private int cylinderCenter;
@@ -68,13 +69,8 @@ public class SnipeData {
         this.cylinderCenter = VoxelSniperConfiguration.DEFAULT_CYLINDER_CENTER;
         this.range = 0;
 
-        this.ranged = false;
-        this.lightning = false;
-
-        this.voxelInkKey = null;
-        this.voxelInkValue = null;
-        this.replaceInkKey = null;
-        this.replaceInkValue = null;
+        voxelInkTraits = new HashMap<>();
+        replaceInkTraits = new HashMap<>();
     }
 
     public double getBrushSize() {
@@ -111,6 +107,8 @@ public class SnipeData {
 
     public void setReplaceState(BlockState state) {
         this.replaceState = state;
+        this.replaceInkTraits.clear();
+        this.replaceInkTraits.putAll(state.getTraitMap());
     }
 
     public int getVoxelHeight() {
@@ -122,7 +120,7 @@ public class SnipeData {
     }
 
     public String getVoxelId() {
-        return voxelState.getId();
+        return this.voxelState.getId();
     }
 
     public BlockState getVoxelState() {
@@ -131,10 +129,12 @@ public class SnipeData {
 
     public void setVoxelState(BlockState state) {
         this.voxelState = state;
+        this.voxelInkTraits.clear();
+        this.voxelInkTraits.putAll(state.getTraitMap());
     }
 
     public VoxelList getVoxelList() {
-        return this.voxelList;
+        return voxelList;
     }
 
     public void setVoxelList(VoxelList voxelList) {
@@ -142,7 +142,7 @@ public class SnipeData {
     }
 
     public Message getVoxelMessage() {
-        return this.voxelMessage;
+        return voxelMessage;
     }
 
     public void setVoxelMessage(Message voxelMessage) {
@@ -150,11 +150,11 @@ public class SnipeData {
     }
 
     public World getWorld() {
-        return this.owner.getPlayer().getWorld();
+        return owner.getPlayer().getWorld();
     }
 
     public boolean isLightningEnabled() {
-        return this.lightning;
+        return lightning;
     }
 
     public void setLightningEnabled(boolean lightning) {
@@ -162,37 +162,33 @@ public class SnipeData {
     }
 
     public boolean isRanged() {
-        return this.ranged;
+        return ranged;
     }
 
     public void setRanged(boolean ranged) {
         this.ranged = ranged;
     }
 
-    public Key<? extends BaseValue<?>> getVoxelInkKey() {
-        return this.voxelInkKey;
+    public Map<BlockTrait<?>, Object> getVoxelInkTraits() {
+        return Collections.unmodifiableMap(voxelInkTraits);
     }
 
-    public Object getVoxelInkValue() {
-        return this.voxelInkValue;
+    // Attempts to add the traitValues as the current placement ink.  If the trait values can't be used with the current
+    // voxel state, no changes are made.
+    public void setVoxelInkTraits(Map<BlockTrait<?>, Object> traitValues) {
+        this.voxelInkTraits.clear();
+        this.voxelInkTraits.putAll(traitValues);
     }
 
-    public <V extends BaseValue<T>, T> void setVoxelInk(Key<V> key, T value) {
-        this.voxelInkKey = key;
-        this.voxelInkValue = value;
+    public Map<BlockTrait<?>, Object> getReplaceInkTraits() {
+        return Collections.unmodifiableMap(replaceInkTraits);
     }
 
-    public Key<? extends BaseValue<?>> getReplaceInkKey() {
-        return this.replaceInkKey;
-    }
-
-    public Object getReplaceInkValue() {
-        return this.replaceInkValue;
-    }
-
-    public <V extends BaseValue<T>, T> void setReplaceInk(Key<V> key, T value) {
-        this.replaceInkKey = key;
-        this.replaceInkValue = value;
+    // Attempts to add the traitValues as the current replacement ink.  If the trait values can't be used with the
+    // current replacement state, no changes are made.
+    public void setReplaceInkTraits(Map<BlockTrait<?>, Object> traitValues) {
+        this.replaceInkTraits.clear();
+        this.replaceInkTraits.putAll(traitValues);
     }
 
     public Sniper owner() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/Sniper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/Sniper.java
@@ -48,6 +48,7 @@ import org.spongepowered.api.util.blockray.BlockRayHit;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.UUID;
@@ -129,8 +130,7 @@ public class Sniper {
             }
 
             SnipeData snipeData = sniperTool.getSnipeData();
-            if (player.get(Keys.IS_SNEAKING).orElse(false)) {
-                Location<World> targetBlock = null;
+            if (player.getOrElse(Keys.IS_SNEAKING, false)) {
                 SnipeAction snipeAction = sniperTool.getActionAssigned(itemInHand.getType());
 
                 Predicate<BlockRayHit<World>> filter = BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1);
@@ -139,6 +139,7 @@ public class Sniper {
                     rayBuilder.distanceLimit(snipeData.getRange());
                 }
                 BlockRay<World> ray = rayBuilder.build();
+                Location<World> targetBlock = null;
                 while (ray.hasNext()) {
                     targetBlock = ray.next().getLocation();
                 }
@@ -436,10 +437,11 @@ public class Sniper {
         private Brush instanciateBrush(Class<? extends Brush> brush) {
             // TODO: Check errors here and report.
             try {
-                return brush.newInstance();
-            } catch (InstantiationException e) {
-                return null;
-            } catch (IllegalAccessException e) {
+                return brush.getConstructor().newInstance();
+            } catch (InstantiationException |
+                     IllegalAccessException |
+                     NoSuchMethodException  |
+                     InvocationTargetException e) {
                 return null;
             }
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
@@ -107,11 +107,7 @@ public abstract class PerformBrush extends Brush {
         BlockState current = this.world.getBlock(x, y, z);
         switch (replaceMethod) {
             case TYPE:
-<<<<<<< HEAD
-                if (current.getType() != v.getReplaceState().getType()) {
-=======
                 if (!sameBlockType(current, v.getReplaceState())) {
->>>>>>> 8e15cbd... Updating the ink performers to work better
                     return false;
                 }
                 break;
@@ -121,12 +117,8 @@ public abstract class PerformBrush extends Brush {
                 }
                 break;
             case COMBO:
-<<<<<<< HEAD
-                if (current != v.getReplaceState()) {
-=======
                 if (!sameBlockType(current, v.getReplaceState()) ||
                     !BlockHelper.hasTraits(current, v.getReplaceInkTraits())) {
->>>>>>> 8e15cbd... Updating the ink performers to work better
                     return false;
                 }
                 break;

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
@@ -46,29 +46,35 @@ public abstract class PerformBrush extends Brush {
 
     private static final Pattern PERFORMER = Pattern.compile("([mic])([mic]?)(p?)");
 
-    protected PerformerType placeMethod = PerformerType.TYPE;
-    protected PerformerType replaceMethod = PerformerType.NONE;
-    protected boolean usePhysics = true;
+    protected PerformerType placeMethod;
+    protected PerformerType replaceMethod;
+    protected boolean usePhysics;
+
+    public PerformBrush() {
+        this.placeMethod = PerformerType.TYPE;
+        this.replaceMethod = PerformerType.NONE;
+        this.usePhysics = true;
+    }
 
     public void parse(String[] args, SnipeData v) {
         String handle = args[0].toLowerCase();
         Matcher performersMatch = PERFORMER.matcher(handle);
 
         if (performersMatch.matches()) {
-            placeMethod = stringToMethod(performersMatch.group(1));
-            if (placeMethod == PerformerType.NONE) {
+            this.placeMethod = stringToMethod(performersMatch.group(1));
+            if (this.placeMethod == PerformerType.NONE) {
                 throw new IllegalArgumentException("Unknown placement method '" + performersMatch.group(1) + "'");
             }
 
-            replaceMethod = stringToMethod(performersMatch.group(2));
-            usePhysics = !performersMatch.group(3).equals("p");
+            this.replaceMethod = stringToMethod(performersMatch.group(2));
+            this.usePhysics = !performersMatch.group(3).equals("p");
 
             parameters(Arrays.copyOfRange(args, 1, args.length), v);
         } else {
             parameters(args, v);
         }
 
-        v.getVoxelMessage().performerData(placeMethod, replaceMethod, usePhysics);
+        v.getVoxelMessage().performerData(this.placeMethod, this.replaceMethod, this.usePhysics);
     }
 
     private PerformerType stringToMethod(String rawMethod) {
@@ -84,13 +90,9 @@ public abstract class PerformBrush extends Brush {
     }
 
     public void showInfo(Message vm) {
-        String name = placeMethod.name().toLowerCase();
-        if (replaceMethod != PerformerType.NONE) {
-            name += replaceMethod.name().toLowerCase();
-        }
-        vm.performerData(placeMethod, replaceMethod, usePhysics);
+        vm.performerData(this.placeMethod, this.replaceMethod, this.usePhysics);
         vm.voxel();
-        if (replaceMethod != PerformerType.NONE) {
+        if (this.replaceMethod != PerformerType.NONE) {
             vm.replace();
         }
     }
@@ -105,7 +107,7 @@ public abstract class PerformBrush extends Brush {
         }
 
         BlockState current = this.world.getBlock(x, y, z);
-        switch (replaceMethod) {
+        switch (this.replaceMethod) {
             case TYPE:
                 if (!sameBlockType(current, v.getReplaceState())) {
                     return false;
@@ -128,7 +130,7 @@ public abstract class PerformBrush extends Brush {
         }
 
         BlockChangeFlag physicsFlags = usePhysics ? BlockChangeFlags.ALL : BlockChangeFlags.NONE;
-        switch (placeMethod) {
+        switch (this.placeMethod) {
             case TYPE:
                 setBlockType(x, y, z, v.getVoxelState().getType(), physicsFlags);
                 break;
@@ -141,7 +143,7 @@ public abstract class PerformBrush extends Brush {
                 break;
             case NONE:
             default:
-                throw new IllegalStateException("Unsupported place type " + placeMethod.name());
+                throw new IllegalStateException("Unsupported place type " + this.placeMethod);
         }
         return true;
     }
@@ -168,7 +170,7 @@ public abstract class PerformBrush extends Brush {
                     return "None";
             }
 
-            return "Unkown";
+            return "Unknown";
         }
     }
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/FillDownBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/FillDownBrush.java
@@ -79,7 +79,7 @@ public class FillDownBrush extends PerformBrush {
                         }
                     }
                     for (; y >= 0; y--) {
-                        if (this.replace != PerformerType.NONE) {
+                        if (replaceMethod != PerformerType.NONE) {
                             if (!perform(v, x, y, z)) {
                                 break;
                             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelListCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelListCommand.java
@@ -28,6 +28,7 @@ import com.thevoxelbox.voxelsniper.SnipeData;
 import com.thevoxelbox.voxelsniper.Sniper;
 import com.thevoxelbox.voxelsniper.SniperManager;
 import com.thevoxelbox.voxelsniper.VoxelSniperConfiguration;
+import com.thevoxelbox.voxelsniper.util.BlockHelper;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
@@ -41,10 +42,6 @@ import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
-import org.spongepowered.api.util.blockray.BlockRay;
-import org.spongepowered.api.util.blockray.BlockRay.BlockRayBuilder;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 
 import java.util.Optional;
 
@@ -67,13 +64,7 @@ public class VoxelListCommand implements CommandExecutor {
         Optional<String> oargs = gargs.getOne("args");
         SnipeData snipeData = sniper.getSnipeData(sniper.getCurrentToolId());
         if (!oargs.isPresent()) {
-            Location<World> targetBlock = null;
-            BlockRayBuilder<World> rayBuilder = BlockRay.from(player).stopFilter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1));
-            BlockRay<World> ray = rayBuilder.build();
-            while (ray.hasNext()) {
-                targetBlock = ray.next().getLocation();
-            }
-            snipeData.getVoxelList().add(targetBlock.getBlock());
+            snipeData.getVoxelList().add(BlockHelper.stateOrWhereLooking(Optional.empty(), player).get());
             snipeData.getVoxelMessage().voxelList();
             return CommandResult.success();
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelPerformerCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelPerformerCommand.java
@@ -48,13 +48,13 @@ public class VoxelPerformerCommand implements CommandExecutor {
         Sponge.getCommandManager().register(plugin,
                 CommandSpec.builder().arguments(GenericArguments.playerOrSource(Text.of("sniper")), GenericArguments.string(Text.of("performer")))
                         .executor(new VoxelPerformerCommand()).permission(VoxelSniperConfiguration.PERMISSION_SNIPER)
-                        .description(Text.of("VoxelSniper performer selection")).build(),
+                        .description(usageText()).build(),
                 "p");
     }
 
     @Override
     public CommandResult execute(CommandSource src, CommandContext gargs) throws CommandException {
-        Player player = (Player) gargs.getOne("sniper").get();
+        Player player = gargs.<Player>getOne("sniper").get();
         Sniper sniper = SniperManager.get().getSniperForPlayer(player);
         SnipeData snipeData = sniper.getSnipeData(sniper.getCurrentToolId());
 
@@ -62,10 +62,29 @@ public class VoxelPerformerCommand implements CommandExecutor {
 
         Brush brush = sniper.getBrush(sniper.getCurrentToolId());
         if (brush instanceof PerformBrush) {
-            ((PerformBrush) brush).parse(new String[] { performer }, snipeData);
+            PerformBrush pBrush = (PerformBrush) brush;
+            pBrush.parse(new String[] { performer }, snipeData);
         } else {
             player.sendMessage(Text.of(TextColors.RED, "This brush is not a performer brush."));
         }
         return CommandResult.success();
+    }
+
+    private static Text usageText() {
+        return Text.of(
+                TextColors.RED,
+                "Performer takes in a string of up to three characters.  The first\n" +
+                        "is required and describes the placement method.  The second describes\n" +
+                        "the replacement method and is optional.  The third letter must be a p\n" +
+                        "and if present means that physics will not be applied when placing\n" +
+                        "blocks.  The either two must be one of: \n\n" +
+                        " - m for material.  Placing/replacing is solely done based on the base\n" +
+                        "   block you have selected.\n\n" +
+                        " - i for ink.  Blocks in the affected area will only have their properties\n" +
+                        "   changed when placing or will only be replace if their properties match\n" +
+                        "   the current ink\n\n" +
+                        " - c for combo.  As the name suggests, placement and replacement will use\n" +
+                        "   both the block type and ink values for placing/replacing."
+        );
     }
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelReplaceCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelReplaceCommand.java
@@ -28,9 +28,9 @@ import com.thevoxelbox.voxelsniper.SnipeData;
 import com.thevoxelbox.voxelsniper.Sniper;
 import com.thevoxelbox.voxelsniper.SniperManager;
 import com.thevoxelbox.voxelsniper.VoxelSniperConfiguration;
+import com.thevoxelbox.voxelsniper.util.BlockHelper;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -41,10 +41,6 @@ import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
-import org.spongepowered.api.util.blockray.BlockRay;
-import org.spongepowered.api.util.blockray.BlockRay.BlockRayBuilder;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 
 import java.util.Optional;
 
@@ -62,38 +58,19 @@ public class VoxelReplaceCommand implements CommandExecutor {
 
     @Override
     public CommandResult execute(CommandSource src, CommandContext gargs) throws CommandException {
-        Player player = (Player) gargs.getOne("sniper").get();
+        Player player = gargs.<Player>getOne("sniper").get();
         Sniper sniper = SniperManager.get().getSniperForPlayer(player);
         SnipeData snipeData = sniper.getSnipeData(sniper.getCurrentToolId());
         Optional<String> material = gargs.getOne("material");
-        if (!material.isPresent()) {
-            Location<World> targetBlock = null;
-            BlockRayBuilder<World> rayBuilder = BlockRay.from(player).stopFilter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1));
-            BlockRay<World> ray = rayBuilder.build();
-            while (ray.hasNext()) {
-                targetBlock = ray.next().getLocation();
-            }
-            snipeData.setReplaceState(targetBlock.getBlock());
-            snipeData.getVoxelMessage().replace();
+
+        Optional<BlockState> newState = BlockHelper.stateOrWhereLooking(material, player);
+        if (!newState.isPresent() && material.isPresent()) {
+            src.sendMessage(Text.of(TextColors.RED, "Unknown block ", material.get()));
             return CommandResult.success();
         }
-        String materialName = material.get();
-        if (!materialName.contains(":")) {
-            materialName = "minecraft:" + materialName;
-        }
-        Optional<BlockType> type = Sponge.getRegistry().getType(BlockType.class, materialName);
-        if (type.isPresent()) {
-            snipeData.setReplaceState(type.get().getDefaultState());
-            snipeData.getVoxelMessage().replace();
-        } else {
-            Optional<BlockState> state = Sponge.getRegistry().getType(BlockState.class, materialName);
-            if (state.isPresent()) {
-                snipeData.setReplaceState(state.get());
-                snipeData.getVoxelMessage().replace();
-            } else {
-                player.sendMessage(Text.of(TextColors.RED, "Material not found."));
-            }
-        }
+        snipeData.setReplaceState(newState.get());
+        snipeData.getVoxelMessage().replace();
+
         return CommandResult.success();
     }
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelVoxelCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelVoxelCommand.java
@@ -28,9 +28,9 @@ import com.thevoxelbox.voxelsniper.SnipeData;
 import com.thevoxelbox.voxelsniper.Sniper;
 import com.thevoxelbox.voxelsniper.SniperManager;
 import com.thevoxelbox.voxelsniper.VoxelSniperConfiguration;
+import com.thevoxelbox.voxelsniper.util.BlockHelper;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -41,10 +41,6 @@ import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
-import org.spongepowered.api.util.blockray.BlockRay;
-import org.spongepowered.api.util.blockray.BlockRay.BlockRayBuilder;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 
 import java.util.Optional;
 
@@ -62,38 +58,19 @@ public class VoxelVoxelCommand implements CommandExecutor {
 
     @Override
     public CommandResult execute(CommandSource src, CommandContext gargs) throws CommandException {
-        Player player = (Player) gargs.getOne("sniper").get();
+        Player player = gargs.<Player>getOne("sniper").get();
         Sniper sniper = SniperManager.get().getSniperForPlayer(player);
         SnipeData snipeData = sniper.getSnipeData(sniper.getCurrentToolId());
         Optional<String> material = gargs.getOne("material");
-        if (!material.isPresent()) {
-            Location<World> targetBlock = null;
-            BlockRayBuilder<World> rayBuilder = BlockRay.from(player).stopFilter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1));
-            BlockRay<World> ray = rayBuilder.build();
-            while (ray.hasNext()) {
-                targetBlock = ray.next().getLocation();
-            }
-            snipeData.setVoxelState(targetBlock.getBlock());
-            snipeData.getVoxelMessage().voxel();
+
+        Optional<BlockState> newState = BlockHelper.stateOrWhereLooking(material, player);
+        if (!newState.isPresent() && material.isPresent()) {
+            src.sendMessage(Text.of(TextColors.RED, "Unknown block ", material.get()));
             return CommandResult.success();
         }
-        String materialName = material.get();
-        if (!materialName.contains(":")) {
-            materialName = "minecraft:" + materialName;
-        }
-        Optional<BlockType> type = Sponge.getRegistry().getType(BlockType.class, materialName);
-        if (type.isPresent()) {
-            snipeData.setVoxelState(type.get().getDefaultState());
-            snipeData.getVoxelMessage().voxel();
-        } else {
-            Optional<BlockState> state = Sponge.getRegistry().getType(BlockState.class, materialName);
-            if (state.isPresent()) {
-                snipeData.setVoxelState(state.get());
-                snipeData.getVoxelMessage().voxel();
-            } else {
-                player.sendMessage(Text.of(TextColors.RED, "Material not found."));
-            }
-        }
+        snipeData.setVoxelState(newState.get());
+        snipeData.getVoxelMessage().voxel();
+
         return CommandResult.success();
     }
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/util/BlockHelper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/util/BlockHelper.java
@@ -24,11 +24,18 @@
  */
 package com.thevoxelbox.voxelsniper.util;
 
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.trait.BlockTrait;
 import org.spongepowered.api.data.property.block.MatterProperty;
 import org.spongepowered.api.data.property.block.MatterProperty.Matter;
 import org.spongepowered.api.data.property.block.SolidCubeProperty;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.util.blockray.BlockRay;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class BlockHelper {
@@ -63,4 +70,42 @@ public class BlockHelper {
         return false;
     }
 
+    public static boolean hasTraits(BlockState state, Map<BlockTrait<?>, Object> traits) {
+        for (Map.Entry<BlockTrait<?>, ?> trait : state.getTraitMap().entrySet()) {
+            Object expectedValue = traits.get(trait.getKey());
+            if (!trait.getValue().equals(expectedValue)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static BlockState addTraits(BlockState state, Map<BlockTrait<?>, Object> traits) {
+        Optional<BlockState> nextState;
+        for (Map.Entry<BlockTrait<?>, Object> traitEntry : traits.entrySet()) {
+            nextState = state.withTrait(traitEntry.getKey(), traitEntry.getValue());
+            if (nextState.isPresent()) {
+                state = nextState.get();
+            }
+        }
+
+        return state;
+    }
+
+    public static Optional<BlockState> stateOrWhereLooking(Optional<String> rawState, Player player) {
+        if (rawState.isPresent()) {
+            return Sponge.getRegistry().getType(BlockState.class, rawState.get());
+        }
+
+        Location<World> targetBlock = null;
+        BlockRay.BlockRayBuilder<World> rayBuilder =
+                BlockRay.from(player).stopFilter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1));
+        BlockRay<World> ray = rayBuilder.build();
+        while (ray.hasNext()) {
+            targetBlock = ray.next().getLocation();
+        }
+
+        return Optional.of(targetBlock.getBlock());
+    }
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/util/BlockTraitHelper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/util/BlockTraitHelper.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of VoxelSniper, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) The VoxelBox <http://thevoxelbox.com>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.thevoxelbox.voxelsniper.util;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.trait.BlockTrait;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.text.Text;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class BlockTraitHelper {
+    /* Attempts to parse all block traits in rawKeyValues. If a failure occurs, 
+     * sends an error message to src and returns empty.  Otherwise, returns a 
+     * mapping from the BlockTraits to the parsed values.
+     */
+    public static Optional<Map<BlockTrait<?>, Object>> parseKeyValues(Collection<String> rawKeyValues,
+                                                                      BlockState target,
+                                                                      CommandSource src) {
+        assert rawKeyValues != null;
+        Map<BlockTrait<?>, Object> traitMap = new HashMap<BlockTrait<?>, Object>();
+        for (String rawKeyValue : rawKeyValues) {
+            if (rawKeyValue.indexOf('=') == -1) {
+                src.sendMessage(Text.of("Unable to parse"));
+                return Optional.empty();
+            }
+
+            String[] params = rawKeyValue.split("=");
+            String key = params[0];
+            String value = params[1];
+
+            Optional<BlockTrait<?>> optTrait = target.getTrait(key);
+            if (!optTrait.isPresent()) {
+                src.sendMessage(Text.of("Unknown block trait '", key, "'"));
+                return Optional.empty();
+            }
+
+            BlockTrait<?> trait = optTrait.get();
+            Optional<?> optValue = trait.parseValue(value);
+            if (!optValue.isPresent()) {
+                src.sendMessage(Text.of("Unknown value '", value, "' for key '", key, "'"));
+                return Optional.empty();
+            }
+            traitMap.put(optTrait.get(), optValue.get());
+        }
+
+        return Optional.of(traitMap);
+    }
+}


### PR DESCRIPTION
In this pull request, I updated how Voxel Sniper was handling performance modifiers on brushes to properly support the material, ink, and combo performers for both the placing and replacing of blocks. With this change, I updated the vi and vir change to take multiple block traits as arguments and ironed out some of the code in v and vr to better handle BlockStates and be more idiomatic.  In addition, I cleaned up some of the naming conventions in SnipeData to be more consistent.  The majority of the files affected by this pull request stem from that.