### PR TITLE
Clean up the naming conventions in SnipeData

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,7 @@ repositories {
 
 // Common dependencies
 dependencies {
-    compile 'com.google.guava:guava:21.0'
-    compile 'org.spongepowered:spongeapi:7.0.0'
-
-    testCompile 'junit:junit:4.11'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+    compile 'org.spongepowered:spongeapi:7.1.0'
 }
 
 // Source compiler configuration
@@ -62,10 +58,6 @@ jar {
 javadoc {
   options.encoding = 'UTF-8'
   options.charSet = 'UTF-8'
-  options.links(
-          'http://docs.guava-libraries.googlecode.com/git-history/v18.0/javadoc/',
-          'https://docs.oracle.com/javase/8/docs/api/'
-  )
   // Disable the crazy super-strict doclint tool in Java 8
   options.addStringOption('Xdoclint:none', '-quiet')
 }
@@ -106,6 +98,6 @@ license {
 }
 
 // Gradle version used for generating the Gradle wrapper
-task wrapper(type: Wrapper) {
-  gradleVersion = '2.10'
+wrapper {
+  gradleVersion = '5.6.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip

--- a/src/main/java/com/thevoxelbox/voxelsniper/Message.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/Message.java
@@ -62,7 +62,7 @@ public class Message {
      * Display Center Parameter.
      */
     public void center() {
-        this.snipeData.sendMessage(TextColors.DARK_BLUE, "Brush Center: ", TextColors.DARK_RED, this.snipeData.getcCen());
+        this.snipeData.sendMessage(TextColors.DARK_BLUE, "Brush Center: ", TextColors.DARK_RED, this.snipeData.getCylinderCenter());
     }
 
     /**

--- a/src/main/java/com/thevoxelbox/voxelsniper/SnipeData.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/SnipeData.java
@@ -34,34 +34,48 @@ import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.World;
 
-import java.util.Optional;
-
 public class SnipeData {
 
     private Sniper owner;
     private Message voxelMessage;
 
-    private double brushSize = VoxelSniperConfiguration.DEFAULT_BRUSH_SIZE;
-    private BlockState voxelId = Sponge.getRegistry().getType(BlockState.class, VoxelSniperConfiguration.DEFAULT_VOXEL_ID).orElse(BlockTypes.AIR.getDefaultState());
-    private BlockState replaceId =
-            Sponge.getRegistry().getType(BlockState.class, VoxelSniperConfiguration.DEFAULT_REPLACE_ID).orElse(BlockTypes.AIR.getDefaultState());
-    private VoxelList voxelList = new VoxelList();
-    private Key<?> voxelInkKey = null;
-    private Object voxelInkValue = null;
-    private Key<?> replaceInkKey = null;
-    private Object replaceInkValue = null;
+    private double brushSize;
+    private BlockState voxelState;
+    private BlockState replaceState;
+    private VoxelList voxelList;
+    private Key<?> voxelInkKey;
+    private Object voxelInkValue;
+    private Key<?> replaceInkKey;
+    private Object replaceInkValue;
 
-    private int voxelHeight = VoxelSniperConfiguration.DEFAULT_VOXEL_HEIGHT;
-    private int cCen = VoxelSniperConfiguration.DEFAULT_CYLINDER_CENTER;
-    private int range = 0;
-    private boolean ranged = false;
-    private boolean lightning = false;
+    private int voxelHeight;
+    private int cylinderCenter;
+    private int range;
+    private boolean ranged;
+    private boolean lightning;
 
     public SnipeData(Sniper vs) {
         this.owner = vs;
-    }
 
-    // @Cleanup these method names are all over the place
+        this.voxelState = Sponge.getRegistry().getType(BlockState.class, VoxelSniperConfiguration.DEFAULT_VOXEL_ID)
+                .orElse(BlockTypes.AIR.getDefaultState());
+        this.replaceState = Sponge.getRegistry().getType(BlockState.class, VoxelSniperConfiguration.DEFAULT_REPLACE_ID)
+                .orElse(BlockTypes.AIR.getDefaultState());
+
+        this.brushSize = VoxelSniperConfiguration.DEFAULT_BRUSH_SIZE;
+        this.voxelList = new VoxelList();
+        this.voxelHeight = VoxelSniperConfiguration.DEFAULT_VOXEL_HEIGHT;
+        this.cylinderCenter = VoxelSniperConfiguration.DEFAULT_CYLINDER_CENTER;
+        this.range = 0;
+
+        this.ranged = false;
+        this.lightning = false;
+
+        this.voxelInkKey = null;
+        this.voxelInkValue = null;
+        this.replaceInkKey = null;
+        this.replaceInkValue = null;
+    }
 
     public double getBrushSize() {
         return this.brushSize;
@@ -71,12 +85,12 @@ public class SnipeData {
         this.brushSize = brushSize;
     }
 
-    public int getcCen() {
-        return this.cCen;
+    public int getCylinderCenter() {
+        return this.cylinderCenter;
     }
 
-    public void setcCen(int cCen) {
-        this.cCen = cCen;
+    public void setCylinderCenter(int cCen) {
+        this.cylinderCenter = cCen;
     }
 
     public int getRange() {
@@ -88,24 +102,15 @@ public class SnipeData {
     }
 
     public String getReplaceId() {
-        return this.replaceId.getId();
+        return this.replaceState.getId();
     }
 
-    public BlockState getReplaceIdState() {
-        return this.replaceId;
+    public BlockState getReplaceState() {
+        return this.replaceState;
     }
 
-    public boolean setReplaceId(String replaceId) {
-        Optional<BlockState> state = Sponge.getRegistry().getType(BlockState.class, replaceId);
-        if (state.isPresent()) {
-            this.replaceId = state.get();
-            return true;
-        }
-        return false;
-    }
-
-    public void setReplaceId(BlockState state) {
-        this.replaceId = state;
+    public void setReplaceState(BlockState state) {
+        this.replaceState = state;
     }
 
     public int getVoxelHeight() {
@@ -117,24 +122,15 @@ public class SnipeData {
     }
 
     public String getVoxelId() {
-        return this.voxelId.getId();
+        return voxelState.getId();
     }
 
-    public BlockState getVoxelIdState() {
-        return this.voxelId;
+    public BlockState getVoxelState() {
+        return this.voxelState;
     }
 
-    public boolean setVoxelId(String voxelId) {
-        Optional<BlockState> state = Sponge.getRegistry().getType(BlockState.class, voxelId);
-        if (state.isPresent()) {
-            this.voxelId = state.get();
-            return true;
-        }
-        return false;
-    }
-
-    public void setVoxelId(BlockState state) {
-        this.voxelId = state;
+    public void setVoxelState(BlockState state) {
+        this.voxelState = state;
     }
 
     public VoxelList getVoxelList() {
@@ -203,22 +199,6 @@ public class SnipeData {
         return this.owner;
     }
 
-    /**
-     * Reset to default values.
-     */
-    public void reset() {
-        this.voxelId = Sponge.getRegistry().getType(BlockState.class, VoxelSniperConfiguration.DEFAULT_VOXEL_ID).orElse(BlockTypes.AIR.getDefaultState());
-        this.replaceId = Sponge.getRegistry().getType(BlockState.class, VoxelSniperConfiguration.DEFAULT_REPLACE_ID).orElse(BlockTypes.AIR.getDefaultState());
-        this.brushSize = VoxelSniperConfiguration.DEFAULT_BRUSH_SIZE;
-        this.voxelHeight = VoxelSniperConfiguration.DEFAULT_VOXEL_HEIGHT;
-        this.cCen = VoxelSniperConfiguration.DEFAULT_CYLINDER_CENTER;
-        this.voxelList = new VoxelList();
-
-        this.voxelInkKey = null;
-        this.voxelInkValue = null;
-        this.replaceInkKey = null;
-        this.replaceInkValue = null;
-    }
 
     public void sendMessage(Object... args) {
         this.owner.getPlayer().sendMessage(Text.of(args));

--- a/src/main/java/com/thevoxelbox/voxelsniper/Sniper.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/Sniper.java
@@ -146,21 +146,11 @@ public class Sniper {
                 case PRIMARY_OFFHAND:
                     switch (snipeAction) {
                     case ARROW:
-//                                    int originalVoxel = snipeData.getVoxelId();
-                        snipeData.setVoxelId(targetBlock.getBlockType().getDefaultState());
-//                                    SniperMaterialChangedEvent event =
-//                                            new SniperMaterialChangedEvent(this, toolId, new MaterialData(originalVoxel, snipeData.getData()),
-//                                                    new MaterialData(snipeData.getVoxelId(), snipeData.getData()));
-//                                    Bukkit.getPluginManager().callEvent(event);
+                        snipeData.setVoxelState(targetBlock.getBlockType().getDefaultState());
                         snipeData.getVoxelMessage().voxel();
                         return true;
                     case GUNPOWDER:
-//                                byte originalData = snipeData.getData();
-                        snipeData.setVoxelId(targetBlock.getBlock());
-//                                SniperMaterialChangedEvent event =
-//                                        new SniperMaterialChangedEvent(this, toolId, new MaterialData(snipeData.getVoxelId(), originalData),
-//                                                new MaterialData(snipeData.getVoxelId(), snipeData.getData()));
-//                                Bukkit.getPluginManager().callEvent(event);
+                        snipeData.setVoxelState(targetBlock.getBlock());
                         snipeData.getVoxelMessage().voxel();
                         return true;
                     default:
@@ -171,21 +161,11 @@ public class Sniper {
                 case SECONDARY_OFFHAND:
                     switch (snipeAction) {
                     case ARROW:
-//                                int originalId = snipeData.getReplaceId();
-                        snipeData.setReplaceId(targetBlock.getBlockType().getDefaultState());
-//                                SniperReplaceMaterialChangedEvent event = new SniperReplaceMaterialChangedEvent(this, toolId,
-//                                        new MaterialData(originalId, snipeData.getReplaceData()),
-//                                        new MaterialData(snipeData.getReplaceId(), snipeData.getReplaceData()));
-//                                Bukkit.getPluginManager().callEvent(event);
+                        snipeData.setReplaceState(targetBlock.getBlockType().getDefaultState());
                         snipeData.getVoxelMessage().replace();
                         return true;
                     case GUNPOWDER:
-//                                byte originalData = snipeData.getReplaceData();
-                        snipeData.setReplaceId(targetBlock.getBlock());
-//                                SniperReplaceMaterialChangedEvent event = new SniperReplaceMaterialChangedEvent(this, toolId,
-//                                        new MaterialData(snipeData.getReplaceId(), originalData),
-//                                        new MaterialData(snipeData.getReplaceId(), snipeData.getReplaceData()));
-//                                Bukkit.getPluginManager().callEvent(event);
+                        snipeData.setReplaceState(targetBlock.getBlock());
                         snipeData.getVoxelMessage().replace();
                         return true;
                     default:

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
@@ -109,7 +109,7 @@ public abstract class PerformBrush extends Brush {
             BlockState current = this.world.getBlock(x, y, z);
             switch (this.replace) {
             case TYPE:
-                if (current.getType() != v.getReplaceIdState().getType()) {
+                if (current.getType() != v.getReplaceState().getType()) {
                     return false;
                 }
                 break;
@@ -117,7 +117,7 @@ public abstract class PerformBrush extends Brush {
                 // @Todo filter by key and value
                 break;
             case COMBO:
-                if (current != v.getReplaceIdState()) {
+                if (current != v.getReplaceState()) {
                     return false;
                 }
                 break;
@@ -128,7 +128,7 @@ public abstract class PerformBrush extends Brush {
         }
         switch (this.place) {
         case TYPE:
-            setBlockType(x, y, z, v.getVoxelIdState().getType(), this.physics ? BlockChangeFlags.ALL : BlockChangeFlags.NONE);
+            setBlockType(x, y, z, v.getVoxelState().getType(), this.physics ? BlockChangeFlags.ALL : BlockChangeFlags.NONE);
             break;
         case STATE:
             BlockState current = this.world.getBlock(x, y, z);
@@ -140,7 +140,7 @@ public abstract class PerformBrush extends Brush {
             setBlockState(x, y, z, place.get(), this.physics ? BlockChangeFlags.ALL : BlockChangeFlags.NONE);
             break;
         case COMBO:
-            setBlockState(x, y, z, v.getVoxelIdState(), this.physics ? BlockChangeFlags.ALL : BlockChangeFlags.NONE);
+            setBlockState(x, y, z, v.getVoxelState(), this.physics ? BlockChangeFlags.ALL : BlockChangeFlags.NONE);
             break;
         case NONE:
         default:

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/chunk/CanyonBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/chunk/CanyonBrush.java
@@ -60,7 +60,7 @@ public class CanyonBrush extends ChunkBrush {
     protected void operate(SnipeData v, Chunk chunk) {
         int minx = chunk.getBlockMin().getX();
         int minz = chunk.getBlockMin().getZ();
-        BlockState fillBlock = v.getVoxelIdState();
+        BlockState fillBlock = v.getVoxelState();
         if (fillBlock.getType() == BlockTypes.AIR) {
             fillBlock = BlockTypes.STONE.getDefaultState();
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/chunk/OceanBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/chunk/OceanBrush.java
@@ -102,7 +102,7 @@ public class OceanBrush extends ChunkBrush {
     protected void operate(SnipeData v, Chunk chunk) {
         int minx = chunk.getBlockMin().getX();
         int minz = chunk.getBlockMin().getZ();
-        BlockState fillBlock = v.getVoxelIdState();
+        BlockState fillBlock = v.getVoxelState();
         if (fillBlock.getType() == BlockTypes.AIR) {
             fillBlock = BlockTypes.DIRT.getDefaultState();
         }
@@ -130,7 +130,7 @@ public class OceanBrush extends ChunkBrush {
                     setBlockType(x0, y, z0, BlockTypes.WATER);
                 }
                 if(this.coverFloor) {
-                    setBlockState(x0, y, z0, v.getVoxelIdState());
+                    setBlockState(x0, y, z0, v.getVoxelState());
                 }
             }
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/misc/RulerBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/misc/RulerBrush.java
@@ -57,7 +57,7 @@ public class RulerBrush extends Brush {
             final Undo undo = new Undo(1);
             Location<World> target = this.targetBlock.add(this.xOff, this.yOff, this.zOff);
             undo.put(target);
-            target.setBlock(v.getVoxelIdState());
+            target.setBlock(v.getVoxelState());
             v.owner().storeUndo(undo);
         }
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/CylinderBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/CylinderBrush.java
@@ -43,8 +43,8 @@ public class CylinderBrush extends PerformBrush {
     }
 
     private void cylinder(SnipeData v, Location<World> targetBlock) {
-        int yStartingPoint = targetBlock.getBlockY() + v.getcCen();
-        int yEndPoint = targetBlock.getBlockY() + v.getVoxelHeight() + v.getcCen();
+        int yStartingPoint = targetBlock.getBlockY() + v.getCylinderCenter();
+        int yEndPoint = targetBlock.getBlockY() + v.getVoxelHeight() + v.getCylinderCenter();
 
         if (yEndPoint < yStartingPoint) {
             yEndPoint = yStartingPoint;
@@ -129,8 +129,8 @@ public class CylinderBrush extends PerformBrush {
                 }
             } else if (parameter.startsWith("c")) {
                 try {
-                    v.setcCen((int) Double.parseDouble(parameter.replace("c", "")));
-                    v.sendMessage(TextColors.AQUA + "Cylinder origin set to: " + v.getcCen());
+                    v.setCylinderCenter((int) Double.parseDouble(parameter.replace("c", "")));
+                    v.sendMessage(TextColors.AQUA + "Cylinder origin set to: " + v.getCylinderCenter());
                 } catch (NumberFormatException e) {
                     v.sendMessage(TextColors.RED, "Invalid origin given.");
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ExtrudeBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ExtrudeBrush.java
@@ -55,7 +55,7 @@ public class ExtrudeBrush extends Brush {
                 if (x * x + z * z < brushSizeSquared) {
                     if (v.getVoxelList().contains(get(x, z, axis, targetBlock))) {
                         for (int y = 0; y < v.getVoxelHeight(); y++) {
-                            set(x, z, axis, targetBlock, v.getVoxelIdState(), y);
+                            set(x, z, axis, targetBlock, v.getVoxelState(), y);
                         }
                     }
                 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/FillDownBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/FillDownBrush.java
@@ -66,7 +66,7 @@ public class FillDownBrush extends PerformBrush {
                     int y = targetBlock.getBlockY();
                     if (this.fromExisting) {
                         for (int y0 = -v.getVoxelHeight(); y0 < v.getVoxelHeight(); y0++) {
-                            if (this.world.getBlock(x, y + y0, z) != v.getReplaceIdState()) {
+                            if (this.world.getBlock(x, y + y0, z) != v.getReplaceState()) {
                                 y += y0 - 1;
                                 break;
                             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ShellBallBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ShellBallBrush.java
@@ -62,30 +62,30 @@ public class ShellBallBrush extends Brush {
                     if (y <= 0 || y >= WORLD_HEIGHT) {
                         continue;
                     }
-                    if (this.world.getBlock(x0, y0, z0) != v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0, z0) != v.getReplaceState()) {
                         continue;
                     }
                     int blocks = 0;
-                    if (this.world.getBlock(x0 + 1, y0, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0 + 1, y0, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0 - 1, y0, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0 - 1, y0, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0 + 1, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0 + 1, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0 - 1, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0 - 1, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0, z0 + 1) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0, z0 + 1) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0, z0 - 1) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0, z0 - 1) == v.getReplaceState()) {
                         blocks++;
                     }
                     if (blocks == 6) {
-                        buffer.set(x, y, z, v.getVoxelIdState());
+                        buffer.set(x, y, z, v.getVoxelState());
                     }
                 }
             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ShellSetBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ShellSetBrush.java
@@ -61,30 +61,30 @@ public class ShellSetBrush extends Brush {
                     if (y <= 0 || y >= WORLD_HEIGHT) {
                         continue;
                     }
-                    if (this.world.getBlock(x, y, z) != v.getReplaceIdState()) {
+                    if (this.world.getBlock(x, y, z) != v.getReplaceState()) {
                         continue;
                     }
                     int blocks = 0;
-                    if (this.world.getBlock(x + 1, y, z) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x + 1, y, z) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x - 1, y, z) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x - 1, y, z) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x, y + 1, z) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x, y + 1, z) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x, y - 1, z) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x, y - 1, z) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x, y, z + 1) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x, y, z + 1) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x, y, z - 1) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x, y, z - 1) == v.getReplaceState()) {
                         blocks++;
                     }
                     if (blocks == 6) {
-                        buffer.set(x, y, z, v.getVoxelIdState());
+                        buffer.set(x, y, z, v.getVoxelState());
                     }
                 }
             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ShellVoxelBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/shape/ShellVoxelBrush.java
@@ -60,30 +60,30 @@ public class ShellVoxelBrush extends Brush {
                     if (y <= 0 || y >= WORLD_HEIGHT) {
                         continue;
                     }
-                    if (this.world.getBlock(x0, y0, z0) != v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0, z0) != v.getReplaceState()) {
                         continue;
                     }
                     int blocks = 0;
-                    if (this.world.getBlock(x0 + 1, y0, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0 + 1, y0, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0 - 1, y0, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0 - 1, y0, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0 + 1, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0 + 1, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0 - 1, z0) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0 - 1, z0) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0, z0 + 1) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0, z0 + 1) == v.getReplaceState()) {
                         blocks++;
                     }
-                    if (this.world.getBlock(x0, y0, z0 - 1) == v.getReplaceIdState()) {
+                    if (this.world.getBlock(x0, y0, z0 - 1) == v.getReplaceState()) {
                         blocks++;
                     }
                     if (blocks == 6) {
-                        buffer.set(x, y, z, v.getVoxelIdState());
+                        buffer.set(x, y, z, v.getVoxelState());
                     }
                 }
             }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelCenterCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelCenterCommand.java
@@ -54,7 +54,7 @@ public class VoxelCenterCommand implements CommandExecutor {
         Player player = (Player) gargs.getOne("sniper").get();
         Sniper sniper = SniperManager.get().getSniperForPlayer(player);
         SnipeData snipeData = sniper.getSnipeData(sniper.getCurrentToolId());
-        snipeData.setcCen((int) gargs.getOne("center").get());
+        snipeData.setCylinderCenter((int) gargs.getOne("center").get());
         snipeData.getVoxelMessage().center();
         return CommandResult.success();
     }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelReplaceCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelReplaceCommand.java
@@ -73,7 +73,7 @@ public class VoxelReplaceCommand implements CommandExecutor {
             while (ray.hasNext()) {
                 targetBlock = ray.next().getLocation();
             }
-            snipeData.setReplaceId(targetBlock.getBlock());
+            snipeData.setReplaceState(targetBlock.getBlock());
             snipeData.getVoxelMessage().replace();
             return CommandResult.success();
         }
@@ -83,12 +83,12 @@ public class VoxelReplaceCommand implements CommandExecutor {
         }
         Optional<BlockType> type = Sponge.getRegistry().getType(BlockType.class, materialName);
         if (type.isPresent()) {
-            snipeData.setReplaceId(type.get().getDefaultState());
+            snipeData.setReplaceState(type.get().getDefaultState());
             snipeData.getVoxelMessage().replace();
         } else {
             Optional<BlockState> state = Sponge.getRegistry().getType(BlockState.class, materialName);
             if (state.isPresent()) {
-                snipeData.setReplaceId(state.get());
+                snipeData.setReplaceState(state.get());
                 snipeData.getVoxelMessage().replace();
             } else {
                 player.sendMessage(Text.of(TextColors.RED, "Material not found."));

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelVoxelCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelVoxelCommand.java
@@ -73,7 +73,7 @@ public class VoxelVoxelCommand implements CommandExecutor {
             while (ray.hasNext()) {
                 targetBlock = ray.next().getLocation();
             }
-            snipeData.setVoxelId(targetBlock.getBlock());
+            snipeData.setVoxelState(targetBlock.getBlock());
             snipeData.getVoxelMessage().voxel();
             return CommandResult.success();
         }
@@ -83,12 +83,12 @@ public class VoxelVoxelCommand implements CommandExecutor {
         }
         Optional<BlockType> type = Sponge.getRegistry().getType(BlockType.class, materialName);
         if (type.isPresent()) {
-            snipeData.setVoxelId(type.get().getDefaultState());
+            snipeData.setVoxelState(type.get().getDefaultState());
             snipeData.getVoxelMessage().voxel();
         } else {
             Optional<BlockState> state = Sponge.getRegistry().getType(BlockState.class, materialName);
             if (state.isPresent()) {
-                snipeData.setVoxelId(state.get());
+                snipeData.setVoxelState(state.get());
                 snipeData.getVoxelMessage().voxel();
             } else {
                 player.sendMessage(Text.of(TextColors.RED, "Material not found."));


### PR DESCRIPTION
The title really says it all.  This pull request cleans up the naming conventions used by SnipeData to be more consistent and easier to understand what the methods are actually for.

This pull request depends on #343 .