### PR TITLE
Cleaning up the brush command

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/Brushes.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/Brushes.java
@@ -32,6 +32,7 @@ import com.thevoxelbox.voxelsniper.event.RegisterBrushEvent;
 import org.spongepowered.api.Sponge;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Brush registration manager.
@@ -78,8 +79,8 @@ public final class Brushes {
         return brushes.size();
     }
 
-    public static String getAllBrushes() {
-        return String.join(", ", brushes.keySet());
+    public static Set<String> getAllBrushes() {
+        return brushes.keySet();
     }
 
     private Brushes() {

--- a/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/brush/PerformBrush.java
@@ -48,40 +48,36 @@ public abstract class PerformBrush extends Brush {
     protected PerformerType replace = PerformerType.NONE;
     protected boolean physics = true;
 
-    public void parse(String[] args, SnipeData v) {
-        String handle = args[0];
+    public boolean setPerformer(String handle) {
+        handle = handle.toLowerCase();
+
         if (PERFORMER.matcher(handle).matches()) {
             char p = handle.charAt(0);
-            if (p == 'm' || p == 'M') {
+            if (p == 'm') {
                 this.place = PerformerType.TYPE;
-            } else if (p == 'c' || p == 'C') {
+            } else if (p == 'c') {
                 this.place = PerformerType.COMBO;
             }
+
             int i = 1;
             if (handle.length() >= 2) {
                 char r = handle.charAt(i);
                 i = 2;
-                if (r == 'm' || r == 'M') {
+                if (r == 'm') {
                     this.replace = PerformerType.TYPE;
-                } else if (r == 'c' || r == 'C') {
+                } else if (r == 'c') {
                     this.replace = PerformerType.COMBO;
                 } else {
                     i = 1;
                     this.replace = PerformerType.NONE;
                 }
             }
-            if (handle.length() >= i + 1) {
-                char e = handle.charAt(i);
-                if (e == 'p' || e == 'P') {
-                    this.physics = false;
-                } else {
-                    this.physics = true;
-                }
-            }
-            parameters(Arrays.copyOfRange(args, 1, args.length), v);
-        } else {
-            parameters(args, v);
+
+            this.physics = handle.length() <= i || handle.charAt(i) != p;
+            return true;
         }
+
+        return false;
     }
 
     public void showInfo(Message vm) {

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/BrushCommandElement.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/BrushCommandElement.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of VoxelSniper, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) The VoxelBox <http://thevoxelbox.com>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.thevoxelbox.voxelsniper.command;
+
+import com.thevoxelbox.voxelsniper.Brushes;
+import com.thevoxelbox.voxelsniper.brush.Brush;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.text.Text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BrushCommandElement extends CommandElement {
+    private List<String> brushes;
+
+    protected BrushCommandElement(Text t) {
+        super(t);
+    }
+
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        CommandArgs.Snapshot argSnapshot = args.getSnapshot();
+        String brushInput = args.next();
+        Class<? extends Brush> brush = Brushes.getBrushForHandle(brushInput);
+
+        if (brush == null) {
+            args.applySnapshot(argSnapshot);
+            throw args.createError(Text.of("Cannot find brush \"" + brushInput + "\""));
+        }
+
+        return brush;
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        if (brushes == null) {
+            brushes = new ArrayList<>(Brushes.getAllBrushes());
+        }
+
+        String nextArg = "";
+        try {
+            nextArg = args.peek();
+        } catch (ArgumentParseException ignored) {}
+
+        List<String> possibleBrushes = new ArrayList<>();
+        for (String brush : brushes) {
+            if (brush.startsWith(nextArg)) {
+                possibleBrushes.add(brush);
+            }
+        }
+
+        return possibleBrushes;
+    }
+}

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelPerformerCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelPerformerCommand.java
@@ -24,6 +24,7 @@
  */
 package com.thevoxelbox.voxelsniper.command;
 
+import com.thevoxelbox.voxelsniper.Message;
 import com.thevoxelbox.voxelsniper.SnipeData;
 import com.thevoxelbox.voxelsniper.Sniper;
 import com.thevoxelbox.voxelsniper.SniperManager;
@@ -62,7 +63,11 @@ public class VoxelPerformerCommand implements CommandExecutor {
 
         Brush brush = sniper.getBrush(sniper.getCurrentToolId());
         if (brush instanceof PerformBrush) {
-            ((PerformBrush) brush).parse(new String[] { performer }, snipeData);
+            if (((PerformBrush) brush).setPerformer(performer)) {
+                (new Message(snipeData)).performerName(performer);
+            } else {
+                player.sendMessage(Text.of(TextColors.RED, "Problem parsing performers \"" + performer  + "\""));
+            }
         } else {
             player.sendMessage(Text.of(TextColors.RED, "This brush is not a performer brush."));
         }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelSniperCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelSniperCommand.java
@@ -41,6 +41,7 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
+import java.util.Iterator;
 import java.util.Optional;
 
 public class VoxelSniperCommand implements CommandExecutor {
@@ -64,7 +65,7 @@ public class VoxelSniperCommand implements CommandExecutor {
             String[] args = oargs.get().split(" ");
             if (args[0].equalsIgnoreCase("brushes")) {
                 player.sendMessage(Text.of(TextColors.AQUA, "All available brushes:"));
-                player.sendMessage(Text.of(Brushes.getAllBrushes()));
+                player.sendMessage(Text.of(getBrushListString()));
                 return CommandResult.success();
             } else if (args[0].equalsIgnoreCase("version")) {
                 player.sendMessage(Text.of(TextColors.AQUA, "VoxelSniper version " + VoxelSniperConfiguration.PLUGIN_VERSION));
@@ -106,5 +107,21 @@ public class VoxelSniperCommand implements CommandExecutor {
         player.sendMessage(Text.of(TextColors.DARK_RED, "VoxelSniper - Current Brush Settings:"));
         sniper.displayInfo();
         return CommandResult.success();
+    }
+
+    private String getBrushListString() {
+        StringBuilder sb = new StringBuilder();
+        Iterator<String> brushes = Brushes.getAllBrushes().iterator();
+        if (!brushes.hasNext()) {
+            return sb.toString();
+        }
+
+        sb.append(brushes.next());
+        while (brushes.hasNext()) {
+            sb.append(", ");
+            sb.append(brushes.next());
+        }
+
+        return sb.toString();
     }
 }

--- a/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelSniperCommand.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/VoxelSniperCommand.java
@@ -65,7 +65,7 @@ public class VoxelSniperCommand implements CommandExecutor {
             String[] args = oargs.get().split(" ");
             if (args[0].equalsIgnoreCase("brushes")) {
                 player.sendMessage(Text.of(TextColors.AQUA, "All available brushes:"));
-                player.sendMessage(Text.of(getBrushListString()));
+                player.sendMessage(Text.of(String.join(", ", Brushes.getAllBrushes())));
                 return CommandResult.success();
             } else if (args[0].equalsIgnoreCase("version")) {
                 player.sendMessage(Text.of(TextColors.AQUA, "VoxelSniper version " + VoxelSniperConfiguration.PLUGIN_VERSION));
@@ -107,21 +107,5 @@ public class VoxelSniperCommand implements CommandExecutor {
         player.sendMessage(Text.of(TextColors.DARK_RED, "VoxelSniper - Current Brush Settings:"));
         sniper.displayInfo();
         return CommandResult.success();
-    }
-
-    private String getBrushListString() {
-        StringBuilder sb = new StringBuilder();
-        Iterator<String> brushes = Brushes.getAllBrushes().iterator();
-        if (!brushes.hasNext()) {
-            return sb.toString();
-        }
-
-        sb.append(brushes.next());
-        while (brushes.hasNext()) {
-            sb.append(", ");
-            sb.append(brushes.next());
-        }
-
-        return sb.toString();
     }
 }


### PR DESCRIPTION
This pull request provides some clean up to the parsing of the brush command's arguments.  The changes include:

- Making the brush size argument explicit, but still optional (i.e. shows up in the usage)
- Added a dedicated Brush command element for parsing the command line brush arguments
- Removing performer consideration from the brush command since we also have the performer command.  I think this makes the brush commander more intuitive and also makes the code cleaner.